### PR TITLE
Add missing AccessRestrictionType to types.bsd

### DIFF
--- a/Schema/Opc.Ua.Types.bsd
+++ b/Schema/Opc.Ua.Types.bsd
@@ -853,6 +853,12 @@
     <opc:Field Name="Permissions" TypeName="tns:PermissionType" />
   </opc:StructuredType>
 
+  <opc:EnumeratedType Name="AccessRestrictionType" LengthInBits="32">
+    <opc:EnumeratedValue Name="SigningRequired" Value="0" />
+    <opc:EnumeratedValue Name="EncryptionRequired" Value="1" />
+    <opc:EnumeratedValue Name="SessionRequired" Value="2" />
+  </opc:EnumeratedType>
+
   <opc:EnumeratedType Name="StructureType" LengthInBits="32">
     <opc:EnumeratedValue Name="Structure" Value="0" />
     <opc:EnumeratedValue Name="StructureWithOptionalFields" Value="1" />


### PR DESCRIPTION
The `Opc.Ua.Types.bsd` is missing the definition for AccessRestrictionType.