### PR TITLE
Fix (30120 IO-Link) 0007373:1:PDDescriptor variable has wrong default value type

### DIFF
--- a/IOLink/Opc.Ua.IOLink.NodeSet2.xml
+++ b/IOLink/Opc.Ua.IOLink.NodeSet2.xml
@@ -111,9 +111,6 @@
       <Reference ReferenceType="HasProperty" IsForward="false">ns=1;i=2002</Reference>
       <Reference ReferenceType="HasTypeDefinition">i=68</Reference>
     </References>
-    <Value>
-      <ListOfByte />
-    </Value>
   </UAVariable>
   <UAVariable NodeId="ns=1;i=6147" BrowseName="1:ProcessDataLength" ParentNodeId="ns=1;i=2002" DataType="Byte">
     <DisplayName>ProcessDataLength</DisplayName>


### PR DESCRIPTION
Remove obsolete, wrong default value.