### PR TITLE
fix: TypeScript transpiling with strict settings

### DIFF
--- a/OpenApi/Constants/TypeScript/opcua_statuscodes.ts
+++ b/OpenApi/Constants/TypeScript/opcua_statuscodes.ts
@@ -271,14 +271,25 @@ export enum StatusCodes {
    GoodCascade = 0x04090000,
    BadDataSetIdInvalid = 0x80E70000,
 }
-
+ 
+interface IUtilsStatusCodeObject {
+   code: number
+}
+ 
 export class StatusUtils {
-   public static toCode(value: number | object | undefined): number {
+   public static toCode(value: number | IUtilsStatusCodeObject | undefined): number {
       if (!value) return 0;
-      let code: number | undefined = typeof value === 'number' ? value : undefined;
-      if (code === undefined) {
-         const field = value["code"];
-         code = typeof field === 'number' ? field : undefined;
+      let code: number | undefined
+      switch (typeof value) {
+         case 'number':
+            code = value
+            break;
+         case 'object':
+            code = value["code"]
+            break;
+         default:
+            code = undefined
+            break;
       }
       return code ?? 0;
    }
@@ -289,23 +300,23 @@ export class StatusUtils {
       }
       return '0x' + text;
    }
-   public static isGood(value: number | object | undefined): boolean {
+   public static isGood(value: number | IUtilsStatusCodeObject | undefined): boolean {
       return (StatusUtils.toCode(value) & 0xD0000000) === 0;
    }
-   public static isUncertain(value: number | object | undefined): boolean {
+   public static isUncertain(value: number | IUtilsStatusCodeObject | undefined): boolean {
       return (StatusUtils.toCode(value) & 0x40000000) !== 0;
    }
-   public static isBad(value: number | object | undefined): boolean {
+   public static isBad(value: number | IUtilsStatusCodeObject | undefined): boolean {
       return (StatusUtils.toCode(value) & 0x80000000) !== 0;
    }
-   public static codeBits(value: number | object | undefined): number {
+   public static codeBits(value: number | IUtilsStatusCodeObject | undefined): number {
       return (StatusUtils.toCode(value) ?? 0 & 0xFFFF0000);
    }
-   public static infoBits(value: number | object | undefined): number {
+   public static infoBits(value: number | IUtilsStatusCodeObject | undefined): number {
       return (StatusUtils.toCode(value) ?? 0 & 0x0000FFFF);
    }
-   public static toText(value: number | object | undefined): string {
+   public static toText(value: number | IUtilsStatusCodeObject | undefined): string {
       const code = StatusUtils.toCode(value);
-      return Object.keys(StatusCodes).find(key => StatusCodes[key] === code) ?? StatusUtils.toHex(code);
+      return Object.keys(StatusCodes).find((key: string) => StatusCodes[key as keyof typeof StatusCodes] === code) ?? StatusUtils.toHex(code);
    }
 }


### PR DESCRIPTION
Using strict type checking does not work with the current provided file.

Settings used:

  /* Strict Type-Checking Options */
    "strict": true /* Enable all strict type-checking options. */,
    "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
    "strictNullChecks": true /* Enable strict null checks. */,
    "strictFunctionTypes": true /* Enable strict checking of function types. */,
    "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
    "strictPropertyInitialization": true /* Enable strict checking of property initialization in classes. */,
    "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
    "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,